### PR TITLE
Move NotConnected error to debug log level

### DIFF
--- a/crates/router/src/dispatcher.rs
+++ b/crates/router/src/dispatcher.rs
@@ -41,7 +41,13 @@ where
                         log::error!("Send failed: {:?}", e)
                     }
                     if let Err(e) = sink.close().await {
-                        log::error!("Connection close failed: {:?}", e)
+                        // Silence the Io::NotConnected error, they show after connection closed
+                        // on macOS only.
+                        if format!("{:?}", e).contains("NotConnected") {
+                            log::debug!("Socket already closed: {:?}", e)
+                        } else {
+                            log::error!("Connection close failed: {:?}", e)
+                        }
                     }
                 });
                 entry.insert(tx);


### PR DESCRIPTION
This error only shows on macos using unix sockets.
```
[2021-02-15T15:15:13Z DEBUG ya_sb_router] Connection with unbound-socket-a7819188-74a8-47a9-93b4-8b33fb63008a closed.
[2021-02-15T15:15:13Z ERROR ya_sb_router::dispatcher] Connection close failed: Io(Os { code: 57, kind: NotConnected, message: "Socket is not connected" })```