### PR TITLE
Connection: return an error if received no response (no EOS)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-service-bus"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 homepage = "https://github.com/golemfactory/yagna"

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -307,6 +307,7 @@ where
             address,
             request_id
         );
+        let eos_address = address.clone();
         let eos_request_id = request_id.clone();
         let do_call = self
             .handler
@@ -347,13 +348,13 @@ where
                 let _ = act.writer.write(GsbMessage::CallReply(reply));
                 fut::ready(got_eos)
             })
-            .then(|got_eos, act, _ctx| {
+            .then(move |got_eos, act, _ctx| {
                 if !got_eos {
                     let _ = act.writer.write(GsbMessage::CallReply(CallReply {
                         request_id: eos_request_id,
-                        code: 0,
-                        reply_type: 0,
-                        data: Default::default(),
+                        code: CallReplyCode::ServiceFailure as i32,
+                        reply_type: Default::default(),
+                        data: format!("No response from {}", eos_address).into_bytes(),
                     }));
                 }
                 fut::ready(())


### PR DESCRIPTION
Returning an empty `Vec<u8>` causes a deserialization error on the receiving side