### PR TITLE
update tomls after transferring from `yagna` repo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,10 @@ name = "ya-service-bus"
 version = "0.4.3"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
-homepage = "https://github.com/golemfactory/yagna"
-repository = "https://github.com/golemfactory/yagna"
+homepage = "https://github.com/golemfactory/ya-service-bus"
+repository = "https://github.com/golemfactory/ya-service-bus"
 license = "LGPL-3.0"
-description="Golem Service Bus"
+description= "Golem Service Bus"
 
 [features]
 default = ["flex"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Yagna service bus (a.k.a. GSB)
+# Golem Service Bus (a.k.a. GSB)
 
 GSB is a message bus allowing Yagna services to communicate with one another.
 It consist of two software components: router (`ya-sb-router`) and client crate
@@ -13,9 +13,9 @@ communication: service calls (one-to-one, bidirectional) and broadcasts
 
 #### Message format
 GSB messages are encoded with protobuf. Message types could be found in
-`proto/protos/gsb_api.proto` file. Each message is prepended with a 64-bit header.
+[`gsb_api.proto`](crates/proto/protos/gsb_api.proto) file. Each message is prepended with a 64-bit header.
 First 4 bytes of the header are interpreted as big-endian singed integer
-encoding message type (for mapping see [MessageType](https://github.com/golemfactory/yagna/blob/865053ae7bf7d832c35ead022a2bc7084d15368e/service-bus/proto/src/lib.rs#L17-L32) enum).
+encoding message type (for mapping see [Packet](https://github.com/golemfactory/ya-service-bus/blob/3b8ff9cd49fb040cdfeee127f42b28e962a0a9f4/crates/proto/protos/gsb_api.proto#L32-L51) enum).
 Next 4 bytes of the header are interpreted as big-endian unsigned integer
 representing message length.
 

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -3,10 +3,10 @@ name = "ya-sb-proto"
 version = "0.3.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
-homepage = "https://github.com/golemfactory/yagna"
-repository = "https://github.com/golemfactory/yagna"
+homepage = "https://github.com/golemfactory/ya-service-bus/crates/proto"
+repository = "https://github.com/golemfactory/ya-service-bus"
 license = "LGPL-3.0"
-description="Golem Service Bus Protocol messages"
+description= "Golem Service Bus Protocol messages"
 
 [features]
 default = ["with-codec"]

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -3,8 +3,8 @@ name = "ya-sb-router"
 version = "0.4.1"
 description = "Service Bus Router"
 authors = ["Golem Factory <contact@golem.network>"]
-homepage = "https://github.com/golemfactory/yagna/service-bus/router"
-repository = "https://github.com/golemfactory/yagna"
+homepage = "https://github.com/golemfactory/ya-service-bus/crates/router"
+repository = "https://github.com/golemfactory/ya-service-bus"
 license = "GPL-3.0"
 edition = "2018"
 

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -3,8 +3,8 @@ name = "ya-sb-util"
 version = "0.1.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
-homepage = "https://github.com/golemfactory/yagna"
-repository = "https://github.com/golemfactory/yagna"
+homepage = "https://github.com/golemfactory/ya-service-bus/crates/util"
+repository = "https://github.com/golemfactory/ya-service-bus"
 license = "LGPL-3.0"
 description="Golem Service Bus: API and Router common code"
 


### PR DESCRIPTION
To fix repo url for https://crates.io/crates/ya-service-bus