### PR TITLE
decrease router connection log verbosity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1660,7 +1660,7 @@ dependencies = [
 
 [[package]]
 name = "ya-sb-router"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "actix",
  "actix-rt",
@@ -1701,7 +1701,7 @@ dependencies = [
 
 [[package]]
 name = "ya-service-bus"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "actix",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-service-bus"
-version = "0.4.7"
+version = "0.4.8"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 homepage = "https://github.com/golemfactory/ya-service-bus"

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-sb-router"
-version = "0.4.3"
+version = "0.4.4"
 description = "Service Bus Router"
 authors = ["Golem Factory <contact@golem.network>"]
 homepage = "https://github.com/golemfactory/ya-service-bus/crates/router"

--- a/crates/router/src/connection.rs
+++ b/crates/router/src/connection.rs
@@ -81,7 +81,7 @@ impl<
                     ctx.stop();
                     return;
                 }
-                log::debug!(
+                log::trace!(
                     "[{:?}] [PING CHECK] no data for: {:?}, sending ping (buffer={})",
                     act.conn_info,
                     since_last,
@@ -123,7 +123,7 @@ where
 {
     fn cleanup(&mut self, ctx: &mut <Self as Actor>::Context) {
         if let Some(instance_id) = self.instance_id.take() {
-            log::debug!("[{:?}] cleanup connection", self.conn_info);
+            log::trace!("[{:?}] cleanup connection", self.conn_info);
             let addr = ctx.address();
             let mut router = self.router.write();
             for service_id in self.services.drain() {
@@ -342,7 +342,7 @@ impl<
                     let handle = ctx.spawn(fut::wrap_stream(rx).fold(
                         (),
                         |_, request, act: &mut Self, ctx| {
-                            log::debug!("[{:?}] new item", act.conn_info);
+                            log::trace!("[{:?}] broadcast new item", act.conn_info);
                             match request {
                                 Ok(broadcast_request) => act.send_message(
                                     GsbMessage::BroadcastRequest(broadcast_request),
@@ -362,7 +362,7 @@ impl<
                                 if r.is_err() {
                                     log::warn!("[{:?}] broadcast forward dropped", act.conn_info);
                                 } else {
-                                    log::debug!("[{:?}] broadcast forwarded", act.conn_info);
+                                    log::trace!("[{:?}] broadcast forwarded", act.conn_info);
                                 }
                                 fut::ready(())
                             })
@@ -425,7 +425,7 @@ impl<
                 self.send_reply(GsbMessage::Ping(Default::default()), ctx);
             }
             GsbMessage::Pong(_) => {
-                log::debug!("[{:?}] pong recv", self.conn_info);
+                log::trace!("[{:?}] pong recv", self.conn_info);
             }
             m => {
                 log::error!("[{:?}] unexpected gsb message: {:?}", self.conn_info, m);
@@ -472,7 +472,7 @@ impl<
             return;
         }
 
-        log::debug!("[{:?}] empty buffer", self.conn_info);
+        log::trace!("[{:?}] empty buffer", self.conn_info);
         for (msg, tx) in self
             .hold_queue
             .drain(..)
@@ -484,7 +484,7 @@ impl<
                 log::error!("[{:?}] failed to notify sender", self.conn_info);
             }
         }
-        log::debug!(
+        log::trace!(
             "[{:?}] on empty buffer, filled {}",
             self.conn_info,
             self.output.buffer_len()

--- a/crates/router/src/connection.rs
+++ b/crates/router/src/connection.rs
@@ -349,7 +349,7 @@ impl<
                                     ctx,
                                 ),
                                 Err(e) => {
-                                    log::warn!(
+                                    log::debug!(
                                         "[{:?}] failed to recv broadcast: {:?}",
                                         act.conn_info,
                                         e


### PR DESCRIPTION
Why:
- it is spamming yagna console on DEBUG level a log

What
- decrease some `debug!` logs into `trace!` ones