### PR TITLE
Reduce the number of forced disconnects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "ya-sb-router"
-version = "0.5.0"
+version = "0.4.5"
 dependencies = [
  "actix",
  "actix-rt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "ya-sb-router"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "actix",
  "actix-rt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "ya-sb-router"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "actix",
  "actix-rt",
@@ -1703,7 +1703,7 @@ dependencies = [
 
 [[package]]
 name = "ya-service-bus"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "actix",
  "actix-rt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-service-bus"
-version = "0.4.9"
+version = "0.4.10"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 homepage = "https://github.com/golemfactory/ya-service-bus"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rand = "0.7.2"
 serde = { version = "1.0.102", features = ["derive"] }
 serde_json = { version = "1.0.48", optional = true }
 thiserror = "1.0.9"
-tokio = { version = "0.2.6", features = ["tcp", "time", "io-util", "signal"] }
+tokio = { version = "0.2.6", features = ["tcp", "time", "io-util", "signal", "dns"] }
 tokio-util = "0.3.0"
 url = "2.1.1"
 semver="0.11.0"

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-sb-router"
-version = "0.5.0"
+version = "0.4.5"
 description = "Service Bus Router"
 authors = ["Golem Factory <contact@golem.network>"]
 homepage = "https://github.com/golemfactory/ya-service-bus/crates/router"

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-sb-router"
-version = "0.4.4"
+version = "0.4.5"
 description = "Service Bus Router"
 authors = ["Golem Factory <contact@golem.network>"]
 homepage = "https://github.com/golemfactory/ya-service-bus/crates/router"

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-sb-router"
-version = "0.4.5"
+version = "0.5.0"
 description = "Service Bus Router"
 authors = ["Golem Factory <contact@golem.network>"]
 homepage = "https://github.com/golemfactory/ya-service-bus/crates/router"

--- a/crates/router/src/router.rs
+++ b/crates/router/src/router.rs
@@ -260,15 +260,18 @@ impl<W: Sink<GsbMessage, Error = ProtocolError> + Unpin + 'static, ConnInfo: Deb
         &mut self,
         service_id: &str,
         connection: &Addr<Connection<W, ConnInfo>>,
-    ) {
+    ) -> bool {
         if let Some(prev_addr) = self.registered_endpoints.remove(service_id) {
             if prev_addr != *connection && prev_addr.connected() {
                 let _ = self
                     .registered_endpoints
                     .insert(service_id.into(), prev_addr);
                 log::error!("attempt for unregister unowned service {}", service_id);
+            } else {
+                return true;
             }
         }
+        false
     }
 
     pub fn subscribe_topic(&mut self, topic_id: String) -> broadcast::Receiver<BroadcastRequest> {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -429,8 +429,7 @@ where
                 .into_actor(self),
             );
         } else {
-            log::error!("unmatched call reply");
-            ctx.stop()
+            log::debug!("unmatched call reply");
         }
 
         if is_full {


### PR DESCRIPTION
- impl `UnregisterRequest` handler; previously any `UnregisterRequest` caused an "unexpected gsb message" error
- do not stop the connection on unmatched call reply

~I believe that the `unregister_service` / `UnregisterReply` were intended to function analogously to `register_service` / `RegisterReply`, thus I'm treating the function signature change as a bug fix.~